### PR TITLE
Type fix / visual improvement for sinc cheat sheet

### DIFF
--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -29,8 +29,6 @@
 		\newcommand{\Th}{2}  % axis scaling below is hard coded!
 		% Schriftgröße der labels
 		\newcommand{\FONTSIZE}{\scriptsize}
-		% Schriftgröße der Pfeile im Mittelkreuz
-		\newcommand{\FONTSIZECROSSARROWS}{\large}
 		% Farbe des Zeitbereiches
 		\newcommand{\TCOLOR}{C0}
 		% Farbe des Frequenzbereiches

--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -10,7 +10,7 @@
 \newcommand{\sinc}{\mathrm{sinc}}
 \newcommand{\rect}{\mathrm{rect}}
 \newcommand{\psinc}{\mathrm{psinc}}
-% quadratisches Blatt?
+% uncomment for quadratic paper
 %\renewcommand{\paperwidth}{\paperheight}
 \begin{document}
 	\begin{tikzpicture}[
@@ -24,18 +24,20 @@
 		},
 		]
 		%
-		% Periode und Impulsbreite
+		% period
 		\newcommand{\T}{5}
-		\newcommand{\Th}{2}  % axis scaling below is hard coded!
-		% Schriftgröße der labels
+		% impulse width
+		\newcommand{\Th}{2}
+		% axis scaling below is hard coded!
+		% label font size
 		\newcommand{\FONTSIZE}{\scriptsize}
-		% Farbe des Zeitbereiches
+		% time domain color
 		\newcommand{\TCOLOR}{C0}
-		% Farbe des Frequenzbereiches
+		% frequency domain color
 		\newcommand{\FCOLOR}{C1}
-		% Dicke der kontinuierlichen Funktionen
+		% line width of continuous functions
 		\newcommand{\LINEWIDTH}{ultra thick}
-		% Größe der Marker der diskreten Funktionen
+		% marker size of discret functions
 		\newcommand{\MARKSIZE}{1.6pt}
 		\pgfmathsetmacro{\W}{pi}
 		\pgfmathsetmacro{\PAPERWIDTHSQUARED}{\paperwidth/32/32*\paperwidth}
@@ -48,14 +50,14 @@
 		%
 		%
 		%
-		%Kreuz in der Mitte
+		% red cross
 		%
 		\draw[C3,ultra thick] (3/8*\paperwidth,1/2*\paperheight) -- (5/8*\paperwidth,1/2*\paperheight);
 		\draw[C3,ultra thick] (1/2*\paperwidth,3/8*\paperheight) -- (1/2*\paperwidth,5/8*\paperheight);
 		%
 		%
 		%
-		%Fortsetzung der Kreuzlinien am Rand
+		% continuation of cross lines at the paper border
 		%
 		\draw[C3,ultra thick] (0,1/2*\paperheight) -- (1/8*\paperwidth,1/2*\paperheight);
 		\draw[C3,ultra thick] (7/8*\paperwidth,1/2*\paperheight) -- (\paperwidth,1/2*\paperheight);
@@ -64,7 +66,7 @@
 		%
 		%
 		%
-		% Abkürzungen der Transformationen in den Ecken
+		% transformation abbreviations in corners
 		%
 		\node[anchor=north west] at (0,\paperheight) (FT) {\Huge \textbf{FT}};
 		\node[anchor=north east] at (\paperwidth,\paperheight) (FS) {\Huge \textbf{FS}};
@@ -82,7 +84,7 @@
 		% FT Plots
 		%
 		%
-		% sinc Zeitbereich
+		% sinc time domain
 		%
 		\begin{axis}[
 			axis lines = middle,
@@ -114,7 +116,7 @@
 			\node[anchor=center] at (axis cs:-2.5,1) {\FONTSIZE $A$};
 		\end{axis}
 		%
-		% sinc Frequenzbereich
+		% sinc frequency domain
 		%
 		\begin{axis}[
 			axis lines = center,
@@ -151,7 +153,7 @@
 		% FS Plots
 		%
 		%
-		% sinc Zeitbereich
+		% sinc time domain
 		%
 		\begin{axis}[
 			axis lines = middle,
@@ -183,7 +185,7 @@
 			\node[anchor=center] at (axis cs:-2.5,1) {\FONTSIZE $A$};
 		\end{axis}
 		%
-		% sinc Frequenzbereich
+		% sinc frequency domain
 		%
 		\begin{axis}[
 			axis lines = center,
@@ -223,7 +225,7 @@
 		% DTFT Plots
 		%
 		%
-		% sinc Zeitbereich
+		% sinc time domain
 		%
 		\begin{axis}[
 			axis lines = middle,
@@ -257,7 +259,7 @@
 			\node[anchor=center] at (axis cs:-5,1) {\FONTSIZE $A$};
 		\end{axis}
 		%
-		% sinc Frequenzbereich
+		% sinc frequency domain
 		%
 		\begin{axis}[
 			axis lines = center,
@@ -294,7 +296,7 @@
 		% DFT Plots
 		%
 		%
-		% sinc Zeitbereich
+		% sinc time domain
 		%
 		\begin{axis}[
 			axis lines = middle,
@@ -328,7 +330,7 @@
 			\node[anchor=center] at (axis cs:-5,1) {\FONTSIZE $A$};
 		\end{axis}
 		%
-		% sinc Frequenzbereich
+		% sinc frequency domain
 		%
 		\begin{axis}[
 			axis lines = center,
@@ -362,10 +364,10 @@
 			\node[anchor=center] at (axis cs:-5,2) {\FONTSIZE $2 A$};
 		\end{axis}
 		%
-		% BEZIEHUNG ZWISCHEN FT UND FS
+		% relation between FT and FS
 		%
 		%
-		% omega zwischen FT und FS
+		% omega between FT and FS
 		%
 		\node at (22/40*\paperwidth,6/8*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\omega}$};
 		%
@@ -373,37 +375,37 @@
 		%
 		\node at (18/40*\paperwidth,6/8*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{t}$};
 		%
-		% geöffneter Feil von FT zu FS
+		% open arrow from FT to FS
 		%
-		% erstes Drittel
+		% first third
 		%
 		\draw[C1,thick] (17/40*\paperwidth,25/32*\paperheight) -- (19/40*\paperwidth,25/32*\paperheight);
 		%
-		% zweites Drittel (30 ° Öffnung)
+		% second third (30 ° open)
 		%
 		% sqrt(3) approx 1.732050808
 		%
 		\draw[C1,thick] (19/40*\paperwidth,25/32*\paperheight) -- (19/40*\paperwidth+1.732050808/2*2/40*\paperwidth,25/32*\paperheight+1/2*2/40*\paperwidth);
 		%
-		% leztes Drittel
+		% last third
 		%
 		\draw[C1,thick,-latex] (21/40*\paperwidth,25/32*\paperheight) -- (23/40*\paperwidth,25/32*\paperheight) node[above]{Sampling};
 		%
-		% Dirac Impulskämme über geöffnetem Pfeil
+		% impulse comb (open arrow)
 		%
 		\node at (22/40*\paperwidth,27/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
 		%
 		\node at (18/40*\paperwidth,27/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
 		%
-		% geschlossener Pfeil von FS zu FT
+		% closed arrow from FS to FT
 		%
 		%\draw[black,thick,latex-] (17/40*\paperwidth,23/32*\paperheight) -- (23/40*\paperwidth,23/32*\paperheight);
 		%
-		% Faltung sinc unter geschlossener Pfeil
+		% convolution sinc closed arrow
 		%
 		%\node at (22/40*\paperwidth,21/32*\paperheight) [align=center,color=\FCOLOR] {\huge $\mathbf{\ast\sinc}$};
 		%
-		% Multiplikation rect unter geschlossenen Pfeil
+		% multiplication rect closed arrow
 		%
 		%\node at (18/40*\paperwidth,21/32*\paperheight) [align=center,color=\TCOLOR] {\huge $\mathbf{\cdot\rect}$};
 		%
@@ -415,142 +417,142 @@
 		%
 		%
 		%
-		% BEZIEHUNG ZWISCHEN DTFT UND DFT
+		% relation between DTFT and DFT
 		%
 		%
-		% omega zwischen DTFT und DTFT
+		% omega between DTFT and DFT
 		%
 		\node at (22/40*\paperwidth,2/8*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\omega}$};
 		%
-		% t zwischen DTFT und DFT
+		% t between DTFT and DFT
 		%
 		\node at (18/40*\paperwidth,2/8*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{t}$};
 		%
-		% geöffneter Feil von DTFT zu DFT
+		% open arrow from DTFT to DFT
 		%
-		% erstes Drittel
+		% first third
 		%
 		\draw[C1,thick] (17/40*\paperwidth,9/32*\paperheight) -- (19/40*\paperwidth,9/32*\paperheight);
 		%
-		% zweites Drittel (30 ° Öffnung)
+		% second third (30 ° open)
 		%
 		% sqrt(3) approx 1.732050808
 		%
 		\draw[C1,thick] (19/40*\paperwidth,9/32*\paperheight) -- (19/40*\paperwidth+1.732050808/2*2/40*\paperwidth,9/32*\paperheight+1/2*2/40*\paperwidth);
 		%
-		% leztes Drittel
+		% last third
 		%
 		\draw[C1,thick,-latex] (21/40*\paperwidth,9/32*\paperheight) -- (23/40*\paperwidth,9/32*\paperheight) node[above]{Sampling};
 		%
-		% Dirac Impulskämme unter geöffnetem Pfeil
+		% dirac comb open arrow
 		%
 		\node at (22/40*\paperwidth,11/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
 		%
 		\node at (18/40*\paperwidth,11/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
 		%
-		% geschlossener Pfeil von DTFT zu DFT
+		% closed arrow from DFT to DTFT
 		%
 		%\draw[black,thick,latex-] (17/40*\paperwidth,7/32*\paperheight) -- (23/40*\paperwidth,7/32*\paperheight);
 		%
-		% Faltung sinc über geschlossener Pfeil
+		% convolution sinc closed arrow
 		%
 		%\node at (22/40*\paperwidth,5/32*\paperheight) [align=center,color=\FCOLOR] {\huge $\mathbf{\ast\psinc}$};
 		%
-		% Multiplikation rect über geschlossenen Pfeil
+		% multiplication rect closed arrow
 		%
 		%\node at (18/40*\paperwidth,5/32*\paperheight) [align=center,color=\TCOLOR] {\huge $\mathbf{\cdot\rect}$};
 		%
 		%
 		%
-		% BEZIEHUNG ZWISCHEN FT UND DTFT
+		% relation between FT and DTFT
 		%
 		%
-		% omega zwischen FT und DTFT
+		% omega between FT and DTFT
 		%
 		\node at (1/4*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\Huge $\mathbf{\omega}$};
 		%
-		% t zwischen FT und FS
+		% t between FT and FS
 		%
 		\node at (1/4*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR,] {\Huge $\mathbf{t}$};
 		%
-		% geöffneter Feil von FT zu DTFT
+		% open arrow from FT to DTFT
 		%
-		% erstes Drittel
+		% first third
 		% 7/32
 		\draw[C0,thick] (9/32*\paperwidth,23/40*\paperheight) -- (9/32*\paperwidth,21/40*\paperheight);
 		%
-		% zweites Drittel (30 ° Öffnung)
+		% second third (30 ° open)
 		%
 		% sqrt(3) approx 1.732050808
 		%
 		\draw[C0,thick] (9/32*\paperwidth,21/40*\paperheight) -- (9/32*\paperwidth+1/2*2/40*\paperheight,21/40*\paperheight-1.732050808/2*2/40*\paperheight);
 		%
-		% leztes Drittel
+		% last third
 		%
 		\draw[C0,thick,-latex] (9/32*\paperwidth,19/40*\paperheight) -- (9/32*\paperwidth,17/40*\paperheight)  node[below]{Sampling};
 		%
-		% Dirac Impulskämme über geöffnetem Pfeil
+		% dirac comb open arrow
 		%
 		\node at (11/32*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\Huge $\mathbf{\ast\Sha}$};
 		%
 		\node at (11/32*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR,] {\Huge $\mathbf{\cdot\Sha}$};
 		%
-		% geschlossener Pfeil von DTFT zu FT
+		% closed arrow from DTFT to FT
 		%
 		\draw[C0,thick,-latex] (7/32*\paperwidth,17/40*\paperheight) -- (7/32*\paperwidth,23/40*\paperheight) node[above]{Interpolation};
 		%
-		% Faltung sinc unter geschlossenem Pfeil
+		% convolution sinc closed arrow
 		%
 		\node at (5/32*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\huge $\mathbf{\cdot\rect}$};
 		%
-		% Multiplikation rect über geschlossenen Pfeil
+		% multiplication rect closed arrow
 		%
 		\node at (5/32*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR,] {\huge $\mathbf{\ast\sinc}$};
 		%
 		%
 		%
-		% BEZIEHUNG ZWISCHEN FS UND DFT
+		% relation between FS and DFT
 		%
 		%
-		% omega zwischen FS und DFT
+		% omega between FS and DFT
 		%
 		\node at (3/4*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\Huge $\mathbf{\omega}$};
 		%
-		% t zwischen FS und DFT
+		% t between FS and DFT
 		%
 		\node at (3/4*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR,] {\Huge $\mathbf{t}$};
 		%
-		% geöffneter Feil von FS zu DFT
+		% closed arrow from FS to DFT
 		%
-		% erstes Drittel
+		% first third
 		% 7/32
 		\draw[C0,thick] (25/32*\paperwidth,23/40*\paperheight) -- (25/32*\paperwidth,21/40*\paperheight);
 		%
-		% zweites Drittel (30 ° Öffnung)
+		% second third (30 ° open)
 		%
 		% sqrt(3) approx 1.732050808
 		%
 		\draw[C0,thick] (25/32*\paperwidth,21/40*\paperheight) -- (25/32*\paperwidth+1/2*2/40*\paperheight,21/40*\paperheight-1.732050808/2*2/40*\paperheight);
 		%
-		% leztes Drittel
+		% last third
 		%
 		\draw[C0,thick,-latex] (25/32*\paperwidth,19/40*\paperheight) -- (25/32*\paperwidth,17/40*\paperheight)  node[below]{Sampling};
 		%
-		% Dirac Impulskämme über geöffnetem Pfeil
+		% dirac comb open arrow
 		%
 		\node at (27/32*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\Huge $\mathbf{\ast\Sha}$};
 		%
 		\node at (27/32*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
 		%
-		% geschlossener Pfeil von DFT zu FS
+		% closed arrow from DFT to FS
 		%
 		\draw[C0,thick,-latex] (23/32*\paperwidth,17/40*\paperheight) -- (23/32*\paperwidth,23/40*\paperheight)  node[above]{Interpolation};
 		%
-		% Faltung psinc links von geschlossenem Pfeil
+		% convolution psinc closed arrow
 		%
 		\node at (21/32*\paperwidth,18/40*\paperheight) [align=center,color=\FCOLOR,] {\huge $\mathbf{\cdot\rect}$};
 		%
-		% Multiplikation rect über geschlossenen Pfeil
+		% multiplication rect closed arrow
 		%
 		\node at (21/32*\paperwidth,22/40*\paperheight) [align=center,color=\TCOLOR,] {\huge $\mathbf{\ast\psinc}$};
 		%

--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -397,23 +397,6 @@
 		%
 		\node at (18/40*\paperwidth,27/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
 		%
-		% closed arrow from FS to FT
-		%
-		%\draw[black,thick,latex-] (17/40*\paperwidth,23/32*\paperheight) -- (23/40*\paperwidth,23/32*\paperheight);
-		%
-		% convolution sinc closed arrow
-		%
-		%\node at (22/40*\paperwidth,21/32*\paperheight) [align=center,color=\FCOLOR] {\huge $\mathbf{\ast\sinc}$};
-		%
-		% multiplication rect closed arrow
-		%
-		%\node at (18/40*\paperwidth,21/32*\paperheight) [align=center,color=\TCOLOR] {\huge $\mathbf{\cdot\rect}$};
-		%
-		%
-		%
-		%
-		%
-		%
 		%
 		%
 		%
@@ -449,18 +432,6 @@
 		\node at (22/40*\paperwidth,11/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
 		%
 		\node at (18/40*\paperwidth,11/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
-		%
-		% closed arrow from DFT to DTFT
-		%
-		%\draw[black,thick,latex-] (17/40*\paperwidth,7/32*\paperheight) -- (23/40*\paperwidth,7/32*\paperheight);
-		%
-		% convolution sinc closed arrow
-		%
-		%\node at (22/40*\paperwidth,5/32*\paperheight) [align=center,color=\FCOLOR] {\huge $\mathbf{\ast\psinc}$};
-		%
-		% multiplication rect closed arrow
-		%
-		%\node at (18/40*\paperwidth,5/32*\paperheight) [align=center,color=\TCOLOR] {\huge $\mathbf{\cdot\rect}$};
 		%
 		%
 		%
@@ -558,15 +529,6 @@
 		%
 		%
 		%
-		%
-		%
-		%
-		% arrow from FS to DTFT
-		%
-		%\draw[-latex] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Aperiodic + Sampling}
-		%node[below,rotate=\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Periodic + Interpolation} (7.75/20*\paperwidth,7.75/20*\paperheight);
-		%
-		%
 		% arrow from DTFT to FS
 		%
 		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Periodisation + Interpolation \rotatebox{-90}{$\curvearrowleft$}}
@@ -582,34 +544,6 @@
 		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Periodisation + Sampling}
 		node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Sampling + Periodisation} (7.75/20*\paperwidth,12.25/20*\paperheight);
 		%
-		%
-		% arrow from DFT to FT
-		%
-		%\draw[-latex] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Aperiodic + Interpolation}
-		%node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Aperiodic + Interpolation} (7.75/20*\paperwidth,12.25/20*\paperheight);
-		%
-		%
-		%
-		%
-		%
-		%
-		%
-		%
-		%
-		%\draw[black,ultra thick] (0.5/20*\paperwidth,0) -- (0.5/20*\paperwidth,\paperheight);
-		%\draw[black,ultra thick] (8/20*\paperwidth,0) -- (8/20*\paperwidth,\paperheight);
-		%
-		%
-		%\draw[black,ultra thick] (19.5/20*\paperwidth,0) -- (19.5/20*\paperwidth,\paperheight);
-		%\draw[black,ultra thick] (12/20*\paperwidth,0) -- (12/20*\paperwidth,\paperheight);
-		%
-		%
-		%\draw[black,ultra thick] (0,0.5/20*\paperheight) -- (\paperwidth,0.5/20*\paperheight);
-		%\draw[black,ultra thick] (0,8/20*\paperheight) -- (\paperwidth,8/20*\paperheight);
-		%
-		%
-		%\draw[black,ultra thick] (0,12/20*\paperheight) -- (\paperwidth,12/20*\paperheight);
-		%\draw[black,ultra thick] (0,19.5/20*\paperheight) -- (\paperwidth,19.5/20*\paperheight);
 		%
 		%
 		\begin{comment}

--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -533,7 +533,7 @@
 		%
 		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Periodisation + Interpolation \rotatebox{-90}{$\curvearrowleft$}}
 		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Sampling + Aperiodisation \rotatebox{-90}{$\curvearrowleft$} } (12.25/20*\paperwidth,12.25/20*\paperheight);
-		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Interolation + Periodisation}
+		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Interpolation + Periodisation}
 		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Aperiodisation + Sampling} (7.75/20*\paperwidth,7.75/20*\paperheight);
 		%
 		%

--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -531,18 +531,40 @@
 		%
 		% arrow from DTFT to FS
 		%
-		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Periodisation + Interpolation \rotatebox{-90}{$\curvearrowleft$}}
-		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Sampling + Aperiodisation \rotatebox{-90}{$\curvearrowleft$} } (12.25/20*\paperwidth,12.25/20*\paperheight);
-		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Interpolation + Periodisation}
-		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Aperiodisation + Sampling} (7.75/20*\paperwidth,7.75/20*\paperheight);
-		%
-		%
+		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth,anchor=south] {\FONTSIZE Periodisation + Interpolation}
+		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=1/80*\paperwidth,anchor=north] {\FONTSIZE Sampling + Aperiodisation} (12.25/20*\paperwidth,12.25/20*\paperheight) coordinate (A);
+		
+		\coordinate[below right=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (B);
+		\coordinate[above left=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (C);
+		
+		\path[-latex] (B) edge [bend right=90,looseness=2] (C);
+		
+		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth,anchor=south] {\FONTSIZE Interpolation + Periodisation}
+		node[below,rotate=\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth,anchor=north] {\FONTSIZE Aperiodisation + Sampling} (7.75/20*\paperwidth,7.75/20*\paperheight) coordinate (A);
+		
+		\coordinate[below right=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (B);
+		\coordinate[above left=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (C);
+
+		\path[-latex] (B) edge [bend left=90,looseness=2] (C);
+
 		% arrow from FT to DFT
 		%
-		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Sampling + Periodisation \rotatebox{-90}{$\curvearrowleft$}}
-		node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=1/80*\paperwidth] {\FONTSIZE Periodisation + Sampling \rotatebox{-90}{$\curvearrowleft$}} (12.25/20*\paperwidth,7.75/20*\paperheight);
-		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Periodisation + Sampling}
-		node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE \rotatebox{+90}{$\curvearrowright$} Sampling + Periodisation} (7.75/20*\paperwidth,12.25/20*\paperheight);
+		\draw[-latex, ultra thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=1/80*\paperwidth,anchor=south] {\FONTSIZE Sampling + Periodisation}
+		node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=1/80*\paperwidth,anchor=north] {\FONTSIZE Periodisation + Sampling} (12.25/20*\paperwidth,7.75/20*\paperheight) coordinate (A);
+		
+		\coordinate[below left=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (B);
+		\coordinate[above right=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (C);
+		
+		\path[-latex] (B) edge [bend right=90,looseness=2] (C);;
+		
+		
+		\draw[thick] (1/2*\paperwidth,1/2*\paperheight) -- node[above,rotate=-\ANGLE,color=\TCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Periodisation + Sampling}
+		node[below,rotate=-\ANGLE,color=\FCOLOR,xshift=-1/80*\paperwidth] {\FONTSIZE Sampling + Periodisation} (7.75/20*\paperwidth,12.25/20*\paperheight) coordinate (A);
+		
+		\coordinate[below left=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (B);
+		\coordinate[above right=0.75cm*cos(\ANGLE) and 0.75cm*sin(\ANGLE) of A] (C);
+		
+		\path[-latex] (B) edge [bend left=90,looseness=2] (C);;
 		%
 		%
 		%

--- a/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
+++ b/tikz_standalone_ft_fs_dtft_dft sinc_time_rect_frequency.tex
@@ -75,10 +75,10 @@
 		%
 		\node[anchor=north west] at (11/64*\paperwidth,17/20*\paperheight) (wcFT) {\FONTSIZE $\omega_c = \frac{2\pi}{T_c}$};
 		\node[anchor=north west] at (25/32*\paperwidth,17/20*\paperheight) (woFS) {\FONTSIZE $\omega_0 = \frac{2\pi}{T_0}$};
-		\node[anchor=north west] at (25/32*\paperwidth,7/20*\paperheight) (NFFT) {\FONTSIZE $N=10$};
-		\node[anchor=north west] at (24.5/32*\paperwidth,6.5/20*\paperheight) (NFFTnote) {\FONTSIZE exact DFT pair};
-		\node[anchor=north west] at (11/64*\paperwidth,7/20*\paperheight) (WcDTFT) {\FONTSIZE $\Omega_c = \frac{2\pi}{K_c}$};
-		\node[anchor=north west] at (11/64*\paperwidth,6.5/20*\paperheight) (WcDTFTfor) {\FONTSIZE here for $K_c=2$};
+		\node[anchor=north west] at (25/32*\paperwidth,5/20*\paperheight) (NFFT) {\FONTSIZE $N=10$};
+		\node[anchor=north west] at (24.5/32*\paperwidth,4.5/20*\paperheight) (NFFTnote) {\FONTSIZE exact DFT pair};
+		\node[anchor=north west] at (11/64*\paperwidth,5/20*\paperheight) (WcDTFT) {\FONTSIZE $\Omega_c = \frac{2\pi}{K_c}$};
+		\node[anchor=north west] at (11/64*\paperwidth,4.5/20*\paperheight) (WcDTFTfor) {\FONTSIZE here for $K_c=2$};
 		%
 		\node[anchor=north west] at (48.5/128*\paperwidth,2/128*\paperheight) (author) {\tiny Robert Hauser, Frank Schultz, University of Rostock, \url{https://github.com/spatialaudio/signals-and-systems-cheatsheet}, CC BY 4.0, 2024-04-06};
 		% FT Plots
@@ -236,7 +236,7 @@
 			y label style={anchor=west},
 			width = 18/80*\paperwidth,
 			height = 18/80*\paperheight,
-			at = {(1/10*\paperwidth,4/20*\paperheight)},
+			at = {(1/10*\paperwidth,6/20*\paperheight)},
 			xtick = {-15,-10,-5,0,2,5,10,15},
 			xticklabels = {,,$-5$,,$K_c$,$+5$,$+10$,},
 			ytick = {0,0.5,1},
@@ -247,7 +247,7 @@
 			ymax = 1.125,
 			xmin = -17,
 			xmax = 17,
-			anchor = south,
+			anchor = north,
 			]
 			\addplot[domain=-15:15,
 			samples = 31,
@@ -270,7 +270,7 @@
 			y label style={anchor=west},
 			width = 18/80*\paperwidth,
 			height = 18/80*\paperheight,
-			at = {(3/10*\paperwidth,4/20*\paperheight)},
+			at = {(3/10*\paperwidth,6/20*\paperheight)},
 			xtick = {-3*pi,-2*pi,-1*pi,-pi/2,0,pi/2,1*pi,2*pi,3*pi},
 			xticklabels = {,$-2\pi$,,$\frac{-\Omega_c}{2}$,,$\frac{+\Omega_c}{2}$,,$2\pi$,},
 			ytick = {0,1,2},
@@ -281,7 +281,7 @@
 			ymax = 2.25,
 			xmin = -17/15*3*pi,
 			xmax = 17/15*3*pi,
-			anchor=south,
+			anchor=north,
 			]
 			\addplot[domain=-3*pi:3*pi,
 			samples = 257,
@@ -307,7 +307,7 @@
 			y label style={anchor=west},
 			width = 18/80*\paperwidth,
 			height = 18/80*\paperheight,
-			at = {(7/10*\paperwidth,4/20*\paperheight)},
+			at = {(7/10*\paperwidth,6/20*\paperheight)},
 			xtick = {-15,-10,-5,0,5,10,15},
 			xticklabels = {,,$-5$,,$+5$,$+10$,},
 			ytick = {0,0.5,1},
@@ -318,7 +318,7 @@
 			ymax = 1.125,
 			xmin = -17,
 			xmax = 17,
-			anchor = south,
+			anchor = north,
 			]
 			\addplot[domain=-15:15,
 			samples = 31,
@@ -341,7 +341,7 @@
 			y label style={anchor=west},
 			width = 18/80*\paperwidth,
 			height = 18/80*\paperheight,
-			at = {(9/10*\paperwidth,4/20*\paperheight)},
+			at = {(9/10*\paperwidth,6/20*\paperheight)},
 			xtick = {-15,-10,-5,0,5,10,15},
 			xticklabels = {,,$-5$,,$+5$,$+10$,},
 			ytick = {0,1,2},
@@ -352,7 +352,7 @@
 			ymax = 2.25,
 			xmin = -17,
 			xmax = 17,
-			anchor=south,
+			anchor=north,
 			]
 			\addplot[domain=-15:15,
 			samples = 31,
@@ -371,7 +371,7 @@
 		%
 		\node at (22/40*\paperwidth,6/8*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\omega}$};
 		%
-		% t zwischen FT und FS
+		% t between FT and FS
 		%
 		\node at (18/40*\paperwidth,6/8*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{t}$};
 		%
@@ -405,33 +405,33 @@
 		%
 		% omega between DTFT and DFT
 		%
-		\node at (22/40*\paperwidth,2/8*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\omega}$};
+		\node at (22/40*\paperwidth,5/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\omega}$};
 		%
 		% t between DTFT and DFT
 		%
-		\node at (18/40*\paperwidth,2/8*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{t}$};
+		\node at (18/40*\paperwidth,5/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{t}$};
 		%
 		% open arrow from DTFT to DFT
 		%
 		% first third
 		%
-		\draw[C1,thick] (17/40*\paperwidth,9/32*\paperheight) -- (19/40*\paperwidth,9/32*\paperheight);
+		\draw[C1,thick] (17/40*\paperwidth,7/32*\paperheight) -- (19/40*\paperwidth,7/32*\paperheight);
 		%
 		% second third (30 ° open)
 		%
 		% sqrt(3) approx 1.732050808
 		%
-		\draw[C1,thick] (19/40*\paperwidth,9/32*\paperheight) -- (19/40*\paperwidth+1.732050808/2*2/40*\paperwidth,9/32*\paperheight+1/2*2/40*\paperwidth);
+		\draw[C1,thick] (19/40*\paperwidth,7/32*\paperheight) -- (19/40*\paperwidth+1.732050808/2*2/40*\paperwidth,7/32*\paperheight+1/2*2/40*\paperwidth);
 		%
 		% last third
 		%
-		\draw[C1,thick,-latex] (21/40*\paperwidth,9/32*\paperheight) -- (23/40*\paperwidth,9/32*\paperheight) node[above]{Sampling};
+		\draw[C1,thick,-latex] (21/40*\paperwidth,7/32*\paperheight) -- (23/40*\paperwidth,7/32*\paperheight) node[above]{Sampling};
 		%
 		% dirac comb open arrow
 		%
-		\node at (22/40*\paperwidth,11/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
+		\node at (22/40*\paperwidth,9/32*\paperheight) [align=center,color=\FCOLOR] {\Huge $\mathbf{\cdot\Sha}$};
 		%
-		\node at (18/40*\paperwidth,11/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
+		\node at (18/40*\paperwidth,9/32*\paperheight) [align=center,color=\TCOLOR] {\Huge $\mathbf{\ast\Sha}$};
 		%
 		%
 		%


### PR DESCRIPTION
This PR consists of multiple commits:

- switch german comments to english
- typo fix
- curvearrows in mid cross label replaced by bending edge
    - I think that this looks more prettier than curveview in labels because the latter shifts the labels
- a moved the lower plots a little bit more to south